### PR TITLE
Feature/monitering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,9 @@ dependencies {
 
     // json -> jpa
     implementation("com.vladmihalcea:hibernate-types-52:2.16.2")
+
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
 }
 
 dependencyManagement {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,3 +26,10 @@ oauth:
       redirect-url: http://dev.ask-resume.com/api/oauth/google/callback
     linked-in:
       redirect-url: http://dev.ask-resume.com/api/oauth/linked-in/callback
+
+# Actuator Config
+management:
+  endpoint:
+    web:
+      exposure:
+        include: "*"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,3 +31,10 @@ oauth:
       redirect-url: http://localhost:8080/api/oauth/google/callback
     linked-in:
       redirect-url: http://localhost:8080/api/oauth/linked-in/callback
+
+# Actuator Config
+management:
+  endpoint:
+    web:
+      exposure:
+        include: "*"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -40,3 +40,10 @@ oauth:
       redirect-url: https://ask-resume.com/api/oauth/google/callback
     linked-in:
       redirect-url: https://ask-resume.com/api/oauth/linked-in/callback
+
+# Actuator Config
+management:
+  endpoint:
+    web:
+      exposure:
+        include: "*"

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <!--  NOTE : 파일이 생성되는 위치 의논 필요  -->
+    <property name="ACTIVE_PROFILE" value="${spring.profiles.active}" />
+
+    <property name="LOG_PATH" value="/logs" />
+    <!-- log file name -->
+    <property name="LOG_FILE_NAME" value="askResume" />
+    <!-- pattern -->
+    <property name="LOG_DISPLAY_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [ %level ] %logger{36} - %msg%n" />
+
+    <property name="MODULE_PATH" value="app.askresume"/>
+    <property name="HIKARI_PATH" value="com.zaxxer.hikari"/>
+
+    <property name="LOG_LEVEL_ROOT" value="INFO"/>
+    <property name="LOG_LEVEL_API_PATH" value="DEBUG"/>
+    <property name="LOG_LEVEL_HIKARI_PACKAGE" value="INFO"/>
+
+    <appender name="CONSOLE_DISPLAY_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_DISPLAY_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProfile name="${ACTIVE_PROFILE}">
+        <appender name="FILE_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <!-- 파일경로 설정 -->
+            <file>${LOG_PATH}/${LOG_FILE_NAME}-${ACTIVE_PROFILE}.log</file>
+
+            <!-- 출력패턴 설정 -->
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${LOG_DISPLAY_PATTERN}</pattern>
+            </encoder>
+
+            <!-- Rolling 정책 -->
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <!-- .gz,.zip 등을 넣으면 자동 일자별 로그파일 압축 -->
+                <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}-${ACTIVE_PROFILE}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <!-- 파일당 최고 용량 kb, mb, gb -->
+                    <maxFileSize>10MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+
+                <!-- 일자별 로그파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거 -->
+                <maxHistory>30</maxHistory>
+                <!--<MinIndex>1</MinIndex>
+                <MaxIndex>10</MaxIndex> -->
+            </rollingPolicy>
+        </appender>
+
+        <logger name="${MODULE_PATH}"
+                level="${LOG_LEVEL_API_PATH}"
+                additivity="false">
+            <appender-ref ref="FILE_APPENDER"/>
+            <appender-ref ref="CONSOLE_DISPLAY_APPENDER" />
+        </logger>
+
+        <logger name="${HIKARI_PATH}"
+                level="${LOG_LEVEL_HIKARI_PACKAGE}"
+                additivity="false">
+            <appender-ref ref="FILE_APPENDER"/>
+            <appender-ref ref="CONSOLE_DISPLAY_APPENDER" />
+        </logger>
+
+        <root level="${LOG_LEVEL_ROOT}">
+            <appender-ref ref="FILE_APPENDER" />
+            <appender-ref ref="CONSOLE_DISPLAY_APPENDER" />
+        </root>
+
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 작업 사항 
1. Logback 설정
2. Monitering Tool (Prometheus + Grafana) 도입 전 설정

## 상세 내용

### Logback
-  거의 기본 구조로 따라갔으며, 의논 할 부분이 있다면 다음과 같습니다.
1) Log 파일을 저장할 경로.
2) 각 파일 저장 용량 & 저장 주기
3)  `5 Line` 의 `profile.active` 에 따른 설정 적용 여부

- `3)` 번의 경우 사실 로그 파일 이름에 영향을 미침,  ( ex. `askResume-local.log` )
  현재 `local`, `dev` , `prod` 정도 만 각각 적용하고 있어서 크게 문제는 없어 보이긴 함.


### Monitering ( `Prometheus` & `Grafana` )
PR이 `Merge` 되면 직접 서버에서 `Docker` 를 활용해 컨테이너를 배포 할 예정.

- `Prometheus` = `DB`
-  `Grafana` = `DashBoard` 

`Prometheus` 가 `Application`의 `Metric`을 수집하고 `Grafana` 에서 수집된 `Metric`을 가공하여 보여주는 구조

오픈되어 있는 `DashBoard Template` 을 적용해서 각 지표들을 쉽게 볼 수 있게 할 예정입니다.

`JVM` , `CPU`, `Connection` , `Tomcat` 관련 등등 많은 부분을 볼 수 있고 웬만한 `Metric` 은 다 들어가 있던 것으로 확인했습니다.
