### PR TITLE
chore(oauth): OAuth 모듈의 HTTP Client 변경 (WebClient → FeignClient)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     // Kotlin
@@ -82,6 +81,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     // Prometheus
     implementation("io.micrometer:micrometer-registry-prometheus")
+
+    // Feign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation("io.github.openfeign:feign-core:12.4")
+    implementation("io.github.openfeign:feign-slf4j:12.4")
+    implementation("io.github.openfeign:feign-jackson:12.4")
 }
 
 dependencyManagement {

--- a/src/main/kotlin/app/askresume/global/config/WebConfig.kt
+++ b/src/main/kotlin/app/askresume/global/config/WebConfig.kt
@@ -63,8 +63,6 @@ class WebConfig(
             .excludePathPatterns(
                 "/api/oauth/**/login",
                 "/api/oauth/**/callback",
-                "/api/login",
-                "/api/sign-up",
                 "/api/access-token/issue",
                 "/api/logout",
                 "/api/v1/resume/generate",

--- a/src/main/kotlin/app/askresume/oauth/client/OAuthEmailInfoClient.kt
+++ b/src/main/kotlin/app/askresume/oauth/client/OAuthEmailInfoClient.kt
@@ -1,0 +1,17 @@
+package app.askresume.oauth.client
+
+import feign.Headers
+import feign.Param
+import feign.RequestLine
+import java.net.URI
+
+interface OAuthEmailInfoClient {
+
+    @RequestLine("GET")
+    @Headers(value = ["Authorization: {token}"])
+    fun getEmailInfo(
+        emailUrl: URI,
+        @Param("token") token: String,
+    ): Map<String, Any>
+
+}

--- a/src/main/kotlin/app/askresume/oauth/client/OAuthTokenClient.kt
+++ b/src/main/kotlin/app/askresume/oauth/client/OAuthTokenClient.kt
@@ -1,0 +1,22 @@
+package app.askresume.oauth.client
+
+import app.askresume.oauth.dto.OAuthResponse
+import feign.Headers
+import feign.Param
+import feign.RequestLine
+import java.net.URI
+
+interface OAuthTokenClient {
+
+    @RequestLine("POST ?grant_type={grantType}&code={code}&client_id={clientId}&client_secret={clientSecret}&redirect_uri={redirectUri}")
+    @Headers("Content-Type: application/json")
+    fun getToken(
+        tokenUrl: URI,
+        @Param grantType: String,
+        @Param code: String,
+        @Param clientId: String,
+        @Param clientSecret: String,
+        @Param redirectUri: String,
+    ): OAuthResponse.Token
+
+}

--- a/src/main/kotlin/app/askresume/oauth/client/OAuthUserInfoClient.kt
+++ b/src/main/kotlin/app/askresume/oauth/client/OAuthUserInfoClient.kt
@@ -1,0 +1,17 @@
+package app.askresume.oauth.client
+
+import feign.Headers
+import feign.Param
+import feign.RequestLine
+import java.net.URI
+
+interface OAuthUserInfoClient {
+
+    @RequestLine("GET")
+    @Headers(value = ["Authorization: {token}"])
+    fun getUserInfo(
+        userInfoUrl: URI,
+        @Param("token") token: String,
+    ): MutableMap<String, Any>
+
+}

--- a/src/main/kotlin/app/askresume/oauth/constant/OAuthQueryParam.kt
+++ b/src/main/kotlin/app/askresume/oauth/constant/OAuthQueryParam.kt
@@ -4,10 +4,7 @@ enum class OAuthQueryParam(
     val key: String,
 ) {
 
-    GRANT_TYPE("grant_type"),
-    CODE("code"),
     CLIENT_ID("client_id"),
-    CLIENT_SECRET("client_secret"),
     REDIRECT_URI("redirect_uri"),
     RESPONSE_TYPE("response_type"),
     SCOPE("scope"),

--- a/src/main/kotlin/app/askresume/oauth/dto/OAuthResponse.kt
+++ b/src/main/kotlin/app/askresume/oauth/dto/OAuthResponse.kt
@@ -1,5 +1,6 @@
 package app.askresume.oauth.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 
@@ -7,10 +8,15 @@ class OAuthResponse {
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Token(
+        @JsonProperty("access_token")
         val accessToken: String,
+        @JsonProperty("expires_in")
         val expiresIn: Long,
+        @JsonProperty("refresh_token")
         val refreshToken: String?,
+        @JsonProperty("refresh_token_expires_in")
         val refreshTokenExpiresIn: Long?,
+        @JsonProperty("scope")
         val scope: String,
     )
 

--- a/src/main/kotlin/app/askresume/oauth/dto/OAuthResponse.kt
+++ b/src/main/kotlin/app/askresume/oauth/dto/OAuthResponse.kt
@@ -1,12 +1,9 @@
 package app.askresume.oauth.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 class OAuthResponse {
 
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Token(
         @JsonProperty("access_token")
         val accessToken: String,


### PR DESCRIPTION
## 변경 로그
1. OAuth 모듈을 자체 구현하기로 결정

2. 동적 URL을 처리하기 위해 deprecated된 RestTemplate 대신 WebClient를 채택

3. FeignClient로 통일하고 WebFlux 의존성을 제거하자는 의견 검토 #55

4. FeignClient의 동적 URL 지원 기능이 빈약하다는 점 발견 (Content-length 411 에러 등)

5. okhttp, httpClient 의존성을 추가해 해결할 수 있다는 이슈 확인 후 적용 → 여전히 411 발생
https://github.com/OpenFeign/feign/issues/1251

6. 스타터 (spring-cloud-starter-openfeign) 에서 아직 지원하지 않는 12.0 버전 이후부터 해결된 이슈임을 확인
https://github.com/OpenFeign/feign/issues/2068#issue-1732339051

7. io.github.openfeign에서 개별 라이브러리 직접 추가 (12.0 버전 이상)
```kotlin
    implementation("io.github.openfeign:feign-core:12.4")
    implementation("io.github.openfeign:feign-slf4j:12.4")
```

8. 411 에러는 해결됐지만 @RequestLine 어노테이션 사용 시 Jackson Serialize/Deserialize가 적용되지 않는 이슈 발생

9. 별도 제공되는 feign-jackson 의존성 추가 후 feignClientBuilder에 jackson 세팅 추가
```kotlin
    implementation("io.github.openfeign:feign-jackson:12.4")
```
```kotlin
    var feignClientBuilder = Feign.builder()
        .encoder(JacksonEncoder())
        .decoder(JacksonDecoder())
```

10.  기본생성자가 없는 코틀린 data class와 Jackson 라이브러리 사이에 충돌 발생

11. @JasonNaming 어노테이션이 안 먹히는 문제를 @JsonProperty를 하나씩 달아서 해결

```kotlin
class OAuthResponse {

    // WebClient에서만 작동하는 어노테이션 (제거) : @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
    data class Token(
        @JsonProperty("access_token")
        val accessToken: String,
        @JsonProperty("expires_in")
        val expiresIn: Long,
        @JsonProperty("refresh_token")
        val refreshToken: String?,
        @JsonProperty("refresh_token_expires_in")
        val refreshTokenExpiresIn: Long?,
        @JsonProperty("scope")
        val scope: String,
    )

}
```

[Stack Overflow : "cannot deserialize from Object value" 에러 해결법](https://stackoverflow.com/questions/53191468/no-creators-like-default-construct-exist-cannot-deserialize-from-object-valu)

## 관련 문서
(추후 작성) [FeignClient로 동적 URL 처리하기](https://mecd.notion.site/Spring-Boot-FeignClient-URL-9089f3af9239409ebed185c64ce22bdb)